### PR TITLE
INFRA-555: Restrict GITHUB_TOKEN permissions to improve security

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Set up JDK 17


### PR DESCRIPTION
- Set `contents`, `pull-requests` and `actions` permissions to `read`